### PR TITLE
Refactor LLM verification logic and backend comparisons

### DIFF
--- a/src/backend/src/main/java/com/erp/aierpbackend/dto/ClassifyAndVerifyResultDTO.java
+++ b/src/backend/src/main/java/com/erp/aierpbackend/dto/ClassifyAndVerifyResultDTO.java
@@ -65,6 +65,9 @@ public class ClassifyAndVerifyResultDTO {
         
         @JsonProperty("description")
         private String description;
+
+        @JsonProperty("discrepancy_type")
+        private String discrepancyType;
     }
     
     /**
@@ -79,13 +82,16 @@ public class ClassifyAndVerifyResultDTO {
         @JsonProperty("field_name")
         private String fieldName;
         
-        @JsonProperty("confidence")
-        private Double confidence;
+        @JsonProperty("extraction_confidence") // Renamed from confidence
+        private Double extractionConfidence;
         
         @JsonProperty("extracted_value")
         private String extractedValue;
         
         @JsonProperty("verified")
         private Boolean verified;
+
+        @JsonProperty("match_assessment_confidence")
+        private Double matchAssessmentConfidence;
     }
 }

--- a/src/backend/src/main/java/com/erp/aierpbackend/dto/gemini/GeminiDiscrepancy.java
+++ b/src/backend/src/main/java/com/erp/aierpbackend/dto/gemini/GeminiDiscrepancy.java
@@ -10,8 +10,9 @@ import lombok.AllArgsConstructor;
 public class GeminiDiscrepancy {
     private String discrepancyType; // e.g., "VALUE_MISMATCH", "MISSING_IN_DOCUMENT"
     private String fieldName;       // e.g., "header.Sell_to_Customer_Name", "lines.0.Quantity"
-    private String expectedValue;
-    private String actualValue;
-    private String description;     // Pre-formatted by LLM
-    private double confidence;      // LLM's confidence in this specific discrepancy
+    private String erpValue;        // Renamed from expectedValue
+    private String documentValue;   // Renamed from actualValue
+    private String description;     // Pre-formatted by LLM or set by Java
+    private double confidence;      // LLM's confidence in this specific discrepancy (if LLM-generated) or backend confidence
+    private String severity;        // Added field
 }

--- a/src/backend/src/main/java/com/erp/aierpbackend/dto/gemini/GeminiFieldConfidence.java
+++ b/src/backend/src/main/java/com/erp/aierpbackend/dto/gemini/GeminiFieldConfidence.java
@@ -8,8 +8,13 @@ import lombok.AllArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GeminiFieldConfidence {
-    private String fieldName;
+    private String fieldName; // Will contain prefixed name
     private String extractedValue;
-    private double verificationConfidence; // Confidence in the match/mismatch decision
     private double extractionConfidence;   // Confidence in the extracted value itself
+    private Double matchAssessmentConfidence; // Optional: LLM's confidence in a fuzzy match
+    private boolean verified;                 // Whether the field was considered "verified" by some criteria
+    // verificationConfidence is retained if it serves a distinct purpose for backend-only verification steps,
+    // otherwise, it might be redundant if matchAssessmentConfidence covers LLM's comparison attempts.
+    // For now, assuming it might still be used by Java logic. If purely for LLM, it's covered by matchAssessmentConfidence.
+    private double verificationConfidence; // Confidence in the match/mismatch decision (potentially backend determined)
 }

--- a/src/gemini-python-service/app/schemas.py
+++ b/src/gemini-python-service/app/schemas.py
@@ -33,16 +33,18 @@ class IdentifierExtractionResponse(BaseModel):
 
 class Discrepancy(BaseModel):
     field_name: str
-    document_value: str
-    erp_value: str
+    document_value: Optional[str] = None # Made Optional
+    erp_value: Optional[str] = None      # Made Optional
     severity: str = Field(default="medium")
     description: Optional[str] = None
+    discrepancy_type: Optional[str] = None # Added
 
 class FieldConfidence(BaseModel):
-    field_name: str
-    confidence: float
+    field_name: str # Will contain prefixed names like "SalesQuote.CustomerName"
     extracted_value: Optional[str] = None
-    verified: bool = False
+    extraction_confidence: float # Renamed from confidence
+    match_assessment_confidence: Optional[float] = None # Added
+    verified: bool = False # Likely defaults to False from Python now
 
 class ExtractedValues(BaseModel): # Placeholder if you want to return all extracted values
     header: Dict[str, Any] = {}


### PR DESCRIPTION
This commit implements a significant refactoring of the document verification process to improve reliability and maintainability.

Key changes include:

- Python Service (services.py):
  - I replaced the string-based initial classification prompt with structured JSON, improving identifier extraction reliability.
  - I shifted document-specific verification prompts to focus on data extraction rather than LLM-based comparison.
  - I removed the complex, unstructured prompt for cross-document verification; this logic is now primarily handled by the backend.
  - I ensured LLM output for field confidences includes document context in field names (e.g., "SalesQuote.FieldName") for easier parsing by Java.

- Java Service (JobDocumentVerificationService.java):
  - I simplified identifier extraction to use the structured DTO from Python, removing regex fallbacks.
  - I implemented backend comparison logic for strict alphanumeric and numeric checks (including cross-document comparisons) using a new `ComparisonHelper`.
  - The LLM is now primarily queried once for data extraction across all documents, with the backend orchestrating comparisons and discrepancy generation.

- DTOs (Python's schemas.py and Java DTOs):
  - I updated data transfer objects in both services to support new fields like `extraction_confidence`, `match_assessment_confidence`, and `discrepancy_type`, ensuring consistent data exchange.

This new architecture delegates tasks more appropriately: the LLM handles complex data extraction and semantic understanding, while the Java backend manages robust, rule-based comparisons and orchestration.